### PR TITLE
Testing whether a word is plural or not

### DIFF
--- a/lib/inflector.php
+++ b/lib/inflector.php
@@ -458,4 +458,85 @@ class Inflector
 	{
 		return $number . $this->ordinal($number);
 	}
+
+	/**
+	 * Returns true if the word is plural, false otherwise.
+	 * Uncountable words return true.
+	 *
+	 * <pre>
+	 * $this->isPlural('post');       // false
+	 * $this->isPlural('children');   // true
+	 * $this->isPlural('sheep');      // true
+	 * $this->isPlural('words');      // true
+	 * $this->isPlural('CamelChild'); // false
+	 * </pre>
+	 *
+	 * @param string $word
+	 *
+	 * @return bool
+	 */
+	public function is_plural($word)
+	{
+		$rc = (string) $word;
+
+		return $rc && ($this->is_uncountable($word) || $word == $this->apply_inflections($word, $this->inflections->plurals));
+	}
+
+	/**
+	 * Returns true if the word is plural, false otherwise.
+	 * Uncountable words return true.
+	 *
+	 * <pre>
+	 * $this->isSingular('post');       // true
+	 * $this->isSingular('children');   // false
+	 * $this->isSingular('sheep');      // true
+	 * $this->isSingular('words');      // false
+	 * $this->isSingular('CamelChild'); // true
+	 * </pre>
+	 *
+	 * @param string $word
+	 *
+	 * @return bool
+	 */
+	public function is_singular($word)
+	{
+		$rc = (string) $word;
+
+		return $rc && ($this->is_uncountable($word) || $word == $this->apply_inflections($word, $this->inflections->singulars));
+	}
+
+	/**
+	 * Returns true if the word is uncountable, false otherwise.
+	 *
+	 * <pre>
+	 * $this->isSingular('post');       // false
+	 * $this->isSingular('children');   // false
+	 * $this->isSingular('sheep');      // true
+	 * $this->isSingular('words');      // false
+	 * $this->isSingular('CamelChild'); // false
+	 * </pre>
+	 *
+	 * @param string $word
+	 *
+	 * @return bool
+	 */
+	public function is_uncountable($word)
+	{
+		$rc = (string) $word;
+
+		if (!$rc)
+		{
+			return false;
+		}
+
+		if (preg_match('/\b[[:word:]]+\Z/u', downcase($rc), $matches))
+		{
+			if (isset($this->inflections->uncountables[$matches[0]]))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
 }

--- a/tests/InflectionsTest.php
+++ b/tests/InflectionsTest.php
@@ -32,6 +32,45 @@ class InflectionsTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * @dataProvider provide_singular_and_plural
+	 *
+	 * @param string $locale
+	 * @param string $singular
+	 * @param string $plural
+	 */
+	public function test_is_singular($locale, $singular, $plural)
+	{
+		$matched = preg_match('/\b[[:word:]]+\Z/u', downcase($singular), $matches);
+		if ($matched && isset(Inflector::get($locale)->inflections->uncountables[$matches[0]])) {
+			$this->assertTrue(Inflector::get($locale)->is_uncountable($singular));
+			$this->assertTrue(Inflector::get($locale)->is_uncountable($plural));
+		} else {
+			$this->assertTrue(Inflector::get($locale)->is_singular($singular));
+			$this->assertFalse($singular != $plural && Inflector::get($locale)->is_singular($plural));
+		}
+	}
+
+	/**
+	 * @dataProvider provide_singular_and_plural
+	 *
+	 * @param string $locale
+	 * @param string $singular
+	 * @param string $plural
+	 */
+	public function test_is_plural($locale, $singular, $plural)
+	{
+		$matched = preg_match('/\b[[:word:]]+\Z/u', downcase($singular), $matches);
+		if (!$matched) var_dump($matches);
+		if ($matched && isset(Inflector::get($locale)->inflections->uncountables[$matches[0]])) {
+			$this->assertTrue(Inflector::get($locale)->is_uncountable($singular));
+			$this->assertTrue(Inflector::get($locale)->is_uncountable($plural));
+		} else {
+			$this->assertTrue(Inflector::get($locale)->is_plural($plural));
+			$this->assertFalse($singular != $plural && Inflector::get($locale)->is_plural($singular));
+		}
+	}
+
+	/**
 	 * @return array
 	 */
 	public function provide_singular_and_plural()


### PR DESCRIPTION
As discussed in #28, this PR adds three new functions to the inflector class:

*  `is_plural` - whether a word is plural or uncountable
*  `is_singular` - whether a word is singular or uncountable
*  `is_uncountable` - whether a word is uncountable

I have deliberately not added helper functions at this point as this functionality is fairly niche.

---
### Points raised in issue
> Thanks for your suggestion, that could be useful. Instead of applying inflections and checking if the word changes, what do you think about using the plural and singular regexp available in the Inflections instance?

This was not possible because of the catchall regex like `/$/`.

---

### Known bugs
This PR does break the testing because, I believe, the inflections in some languages are incomplete, e.g.:
*  Spanish: `singularize('interés') = 'interé'` which is incorrect
*  Turkish: `pluralize('kirazlar') = 'kirazlarlar'` which is incorrect

Unfortunately, I am not a speaker of these languages and therefore cannot correct them confidently, however some imcomplete suggestions:

```php
// lib/inflections/tr.php
  $inflect
  // Add the negative look behind: "(?<!l[ae]r)"
  ->plural('/([aoıu][^aoıueöiü]{0,6})(?<!l[ae]r)$/u', '\1lar')
  ->plural('/([eöiü][^aoıueöiü]{0,6})(?<!l[ae]r)$/u', '\1ler')
  // ...
     

// lib/inflections/es.php
  $inflect
  // ...
  // Add the negative look behind "(?<!eré)"
  ->singular('/(?<!eré)s$/', '\1')
  // ...
```