### PR TITLE
Replace internal calls to helpers with StaticInflector

### DIFF
--- a/lib/Inflections.php
+++ b/lib/Inflections.php
@@ -178,7 +178,7 @@ final class Inflections
      */
     public function acronym(string $acronym): self
     {
-        $this->acronyms[downcase($acronym)] = $acronym;
+        $this->acronyms[StaticInflector::downcase($acronym)] = $acronym;
         $this->acronym_regex = '/' . implode('|', $this->acronyms) . '/';
 
         return $this;
@@ -252,11 +252,11 @@ final class Inflections
         unset($this->uncountables[$plural]);
 
         $s0 = mb_substr($singular, 0, 1);
-        $s0_upcase = upcase($s0);
+        $s0_upcase = StaticInflector::upcase($s0);
         $srest = mb_substr($singular, 1);
 
         $p0 = mb_substr($plural, 0, 1);
-        $p0_upcase = upcase($p0);
+        $p0_upcase = StaticInflector::upcase($p0);
         $prest = mb_substr($plural, 1);
 
         if ($s0_upcase == $p0_upcase) {
@@ -266,8 +266,8 @@ final class Inflections
             $this->singular("/({$s0}){$srest}$/i", '\1' . $srest);
             $this->singular("/({$p0}){$prest}$/i", '\1' . $srest);
         } else {
-            $s0_downcase = downcase($s0);
-            $p0_downcase = downcase($p0);
+            $s0_downcase = StaticInflector::downcase($s0);
+            $p0_downcase = StaticInflector::downcase($p0);
 
             $this->plural("/{$s0_upcase}(?i){$srest}$/", $p0_upcase . $prest);
             $this->plural("/{$s0_downcase}(?i){$srest}$/", $p0_downcase . $prest);

--- a/lib/Inflector.php
+++ b/lib/Inflector.php
@@ -116,7 +116,7 @@ class Inflector
             return $rc;
         }
 
-        if (preg_match('/\b[[:word:]]+\Z/u', downcase($rc), $matches)) {
+        if (preg_match('/\b[[:word:]]+\Z/u', StaticInflector::downcase($rc), $matches)) {
             if (isset($this->inflections->uncountables[$matches[0]])) {
                 return $rc;
             }
@@ -203,7 +203,7 @@ class Inflector
                 . trim($this->inflections->acronym_regex, '/')
                 . '(?=\b|[[:upper:]_])|\w)/u',
                 function (array $matches): string {
-                    return downcase($matches[0]);
+                    return StaticInflector::downcase($matches[0]);
                 },
                 $string,
                 1
@@ -214,7 +214,7 @@ class Inflector
                 function (array $matches) use ($acronyms): string {
                     $m = $matches[0];
 
-                    return !empty($acronyms[$m]) ? $acronyms[$m] : capitalize($m, true);
+                    return !empty($acronyms[$m]) ? $acronyms[$m] : StaticInflector::capitalize($m, true);
                 },
                 $string,
                 1
@@ -228,7 +228,7 @@ class Inflector
             function (array $matches) use ($acronyms): string {
                 [ , $m1, $m2 ] = $matches;
 
-                return $m1 . ($acronyms[$m2] ?? capitalize($m2, true));
+                return $m1 . ($acronyms[$m2] ?? StaticInflector::capitalize($m2, true));
             },
             $string
         );
@@ -266,7 +266,7 @@ class Inflector
             function (array $matches): string {
                 [ , $m1, $m2 ] = $matches;
 
-                return $m1 . ($m1 ? '_' : '') . downcase($m2);
+                return $m1 . ($m1 ? '_' : '') . StaticInflector::downcase($m2);
             },
             $word
         );
@@ -279,7 +279,7 @@ class Inflector
         $word = preg_replace('/\-+|\s+/', '_', $word);
 
         // @phpstan-ignore-next-line
-        return downcase($word);
+        return StaticInflector::downcase($word);
     }
 
     /**
@@ -315,7 +315,7 @@ class Inflector
             function (array $matches) use ($acronyms): string {
                 [ $m ] = $matches;
 
-                return !empty($acronyms[$m]) ? $acronyms[$m] : downcase($m);
+                return !empty($acronyms[$m]) ? $acronyms[$m] : StaticInflector::downcase($m);
             },
             $result
         );
@@ -324,7 +324,7 @@ class Inflector
 
         // @phpstan-ignore-next-line
         return preg_replace_callback('/^[[:lower:]]/u', function (array $matches): string {
-            return upcase($matches[0]);
+            return StaticInflector::upcase($matches[0]);
         }, $result);
     }
 
@@ -347,7 +347,7 @@ class Inflector
 
         // @phpstan-ignore-next-line
         return preg_replace_callback('/\b(?<![\'’`])[[:lower:]]/u', function (array $matches): string {
-            return upcase($matches[0]);
+            return StaticInflector::upcase($matches[0]);
         }, $str);
     }
 
@@ -438,7 +438,7 @@ class Inflector
         $rc = $word;
 
         return $rc
-            && preg_match('/\b[[:word:]]+\Z/u', downcase($rc), $matches)
+            && preg_match('/\b[[:word:]]+\Z/u', StaticInflector::downcase($rc), $matches)
             && isset($this->inflections->uncountables[$matches[0]]);
     }
 }

--- a/lib/StaticInflector.php
+++ b/lib/StaticInflector.php
@@ -34,10 +34,10 @@ final class StaticInflector
         $end = mb_substr($str, 1);
 
         if (!$preserve_str_end) {
-            $end = downcase($end);
+            $end = self::downcase($end);
         }
 
-        return upcase(mb_substr($str, 0, 1)) . $end;
+        return self::upcase(mb_substr($str, 0, 1)) . $end;
     }
 
     /**


### PR DESCRIPTION
So while you have this warning, the library itself currently leans on these helpers, so much of the does not work without requiring `vendor/icanboogie/inflector/lib/helpers.php`

> [!WARNING]
> Since v3.0 the file with the helper functions is no longer included in the
> autoload.
> You need to include the file `vendor/icanboogie/inflector/lib/helpers.php`
> in your `composer.json` if you want to continue using these functions.

So for instance

```php
<?php

require 'vendor/autoload.php';

use ICanBoogie\Inflector;

echo Inflector::get('en')->pluralize('soup');
```

currently throws

```
Fatal error: Uncaught Error: Call to undefined function ICanBoogie\upcase() in /Users/jdonat/Sites/myon/vendor/icanboogie/inflector/lib/Inflections.php on line 255
```

This PR just changes all the call sites where the helpers are being used internally to use the static inflector instead of helpers