### PR TITLE
Avoid using helpers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   phpunit:
     name: phpunit
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         php-version:
@@ -48,3 +48,32 @@ jobs:
       run: |
         composer global require php-coveralls/php-coveralls
         php-coveralls --coverage_clover=build/logs/clover.xml -v
+
+  test-helpers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: xdebug
+          php-version: "7.1"
+          ini-values: memory_limit=-1
+          tools: composer:v2
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache
+            vendor
+          key: "php-7.1"
+          restore-keys: "php-7.1"
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+
+      - name: Run PHPUnit
+        run: make test
+        env:
+          PHPUNIT_VERSION: "07-helpers"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # CHANGELOG
 
-## 2.x to 3.0
+## v3.0.1
+
+### New requirements
+
+None
+
+### New features
+
+None
+
+### Backward Incompatible Changes
+
+None
+
+### Deprecated Features
+
+None
+
+### Other Changes
+
+Fix: Helpers are used, although they are no longer required by default. @donatj
+
+
+
+## v3.0
 
 ### New requirements
 
@@ -26,7 +50,7 @@ None
 
 
 
-## 1.x to 2.0
+## v2.0
 
 ### New requirements
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -27,4 +27,8 @@
     <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
         <exclude-pattern>*/lib/Inflections/*</exclude-pattern>
     </rule>
+
+    <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+        <exclude-pattern>*/tests/HelpersTest.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpunit07-helpers.xml
+++ b/phpunit07-helpers.xml
@@ -9,17 +9,13 @@
 >
 	<testsuites>
 		<testsuite name="icanboogie/inflector">
-			<directory>tests</directory>
-            <exclude>tests/HelpersTest.php</exclude>
+            <file>tests/HelpersTest.php</file>
 		</testsuite>
 	</testsuites>
 
 	<filter>
 		<whitelist>
 			<directory suffix=".php">lib</directory>
-            <exclude>
-                <file>lib/helpers.php</file>
-            </exclude>
 		</whitelist>
 	</filter>
 </phpunit>

--- a/phpunit11.xml
+++ b/phpunit11.xml
@@ -3,7 +3,7 @@
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.4/phpunit.xsd"
          beStrictAboutCoverageMetadata="true"
          beStrictAboutOutputDuringTests="true"
-         bootstrap="tests/bootstrap.php"
+         bootstrap="vendor/autoload.php"
          colors="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnTestsThatTriggerNotices="true"
@@ -14,11 +14,15 @@
     <testsuites>
         <testsuite name="icanboogie/inflector">
             <directory>tests</directory>
+            <exclude>tests/HelpersTest.php</exclude>
         </testsuite>
     </testsuites>
     <source>
         <include>
             <directory>lib</directory>
         </include>
+        <exclude>
+            <file>lib/helpers.php</file>
+        </exclude>
     </source>
 </phpunit>

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\ICanBoogie;
 
+require_once __DIR__ . '/../lib/helpers.php';
+
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/InflectionsTest.php
+++ b/tests/InflectionsTest.php
@@ -13,12 +13,10 @@ namespace Tests\ICanBoogie;
 
 use ICanBoogie\Inflections;
 use ICanBoogie\InflectionsNotFound;
+use ICanBoogie\StaticInflector;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
-
-use function ICanBoogie\pluralize;
-use function ICanBoogie\singularize;
 
 /**
  * @group integration
@@ -39,7 +37,7 @@ final class InflectionsTest extends TestCase
     #[DataProvider('provide_singular_and_plural')]
     public function test_singular_to_plural(string $locale, string $singular, string $plural): void
     {
-        $this->assertEquals($plural, pluralize($singular, $locale));
+        $this->assertEquals($plural, StaticInflector::pluralize($singular, $locale));
     }
 
     /**
@@ -48,7 +46,7 @@ final class InflectionsTest extends TestCase
     #[DataProvider('provide_singular_and_plural')]
     public function test_plural_to_singular(string $locale, string $singular, string $plural): void
     {
-        $this->assertEquals($singular, singularize($plural, $locale));
+        $this->assertEquals($singular, StaticInflector::singularize($plural, $locale));
     }
 
     // @phpstan-ignore-next-line

--- a/tests/InflectorTest.php
+++ b/tests/InflectorTest.php
@@ -13,9 +13,8 @@ namespace Tests\ICanBoogie;
 
 use ICanBoogie\Inflections;
 use ICanBoogie\Inflector;
+use ICanBoogie\StaticInflector;
 use PHPUnit\Framework\TestCase;
-
-use function ICanBoogie\camelize;
 
 final class InflectorTest extends TestCase
 {
@@ -73,39 +72,39 @@ final class InflectorTest extends TestCase
 
         foreach ($ar as $camel => $underscore) {
             $this->assertEquals($camel, self::$inflector->camelize($underscore));
-            $this->assertEquals($camel, camelize($underscore));
+            $this->assertEquals($camel, StaticInflector::camelize($underscore));
         }
 
         $ar = require __DIR__ . '/cases/camel_to_dash.php';
 
         foreach ($ar as $camel => $dash) {
             $this->assertEquals($camel, self::$inflector->camelize($dash));
-            $this->assertEquals($camel, camelize($dash));
+            $this->assertEquals($camel, StaticInflector::camelize($dash));
         }
     }
 
     public function test_camelize_with_lower_upcases_the_first_letter(): void
     {
         $this->assertEquals('Capital', self::$inflector->camelize('capital'));
-        $this->assertEquals('Capital', camelize('capital'));
+        $this->assertEquals('Capital', StaticInflector::camelize('capital'));
     }
 
     public function test_camelize_preserve_words_ends(): void
     {
         $this->assertEquals('WordOne\\WordTwo', self::$inflector->camelize('wordOne/wordTwo'));
-        $this->assertEquals('WordOne\\WordTwo', camelize('wordOne/wordTwo'));
+        $this->assertEquals('WordOne\\WordTwo', StaticInflector::camelize('wordOne/wordTwo'));
     }
 
     public function test_camelize_with_lower_downcases_the_first_letter(): void
     {
         $this->assertEquals('capital', self::$inflector->camelize('Capital', true));
-        $this->assertEquals('capital', camelize('Capital', true));
+        $this->assertEquals('capital', StaticInflector::camelize('Capital', true));
     }
 
     public function test_camelize_with_underscores(): void
     {
         $this->assertEquals("CamelCase", self::$inflector->camelize('Camel_Case'));
-        $this->assertEquals("CamelCase", camelize('Camel_Case'));
+        $this->assertEquals("CamelCase", StaticInflector::camelize('Camel_Case'));
     }
 
     public function test_acronyms(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,0 @@
-<?php
-
-require __DIR__ . '/../vendor/autoload.php';
-require __DIR__ . '/../lib/helpers.php';


### PR DESCRIPTION
Follow up to https://github.com/ICanBoogie/Inflector/pull/43

- Replace the usage of helper functions with `StaticInflector` calls.
- Run main tests without including helpers.
- Run helper tests in a separate suite